### PR TITLE
Fixup some includes

### DIFF
--- a/wos/sub/wos_hal_killer.s
+++ b/wos/sub/wos_hal_killer.s
@@ -64,9 +64,9 @@ oldintreq:
 ;-------------- v39 Sprites-Fix by CJ/SAE
 	ifnd	NOSPRITESFIX
 	ifd	WOSASSIGN
-		include	wos:sub/fixsprites.s
+		include	wos:sub/FixSprites.s
 	else
-		include	sub/fixsprites.s
+		include	sub/FixSprites.s
 	endc
 	endc
 

--- a/wos/sub/wos_hal_system.s
+++ b/wos/sub/wos_hal_system.s
@@ -49,9 +49,9 @@ getvbr	;movec   vbr,d0
 ;-------------- v39 Sprites-Fix by CJ/SAE
 	ifnd	NOSPRITESFIX
 	ifd	WOSASSIGN
-		include	wos:sub/fixsprites.s
+		include	wos:sub/FixSprites.s
 	else
-		include	sub/fixsprites.s
+		include	sub/FixSprites.s
 	endc
 	endc
 

--- a/wos/wos_v1.63.s
+++ b/wos/wos_v1.63.s
@@ -5511,7 +5511,7 @@ tp_module:
 		ifd     TP3MOD
 			TP3MOD
 		else
-			WOSINCBIN	dat/virgill-noxious.tp3
+			WOSINCBIN	dat/Virgill-Noxious.tp3
 		endc
 		even
 	endc

--- a/wos/wos_v1.63.s
+++ b/wos/wos_v1.63.s
@@ -204,7 +204,7 @@ use set -1	;dummy for p61.i and especially for OMA 3. just leave it here!
 	endc
 
 	ifne	WOS_TP3
-		WOSINCLUDE	sub/replay/tp3.i
+		WOSINCLUDE	sub/replay/TP3.i
 	endc
 
 	ifne	WOS_THX


### PR DESCRIPTION
When cross-compiling on some systems (like Linux and some macOS systems), the casing of includes does matter.

So let's match the in-repo casing with the includes.

These are only the things I noticed by compilation errors so far, I *know* there's more. I might add some more to this PR while hacking, though.